### PR TITLE
feat: add requestHeadersEnvVar to pingdomConfig

### DIFF
--- a/api/v1alpha1/endpointmonitor_types.go
+++ b/api/v1alpha1/endpointmonitor_types.go
@@ -244,9 +244,14 @@ type PingdomConfig struct {
 	// +optional
 	NotifyWhenBackUp bool `json:"notifyWhenBackUp,omitempty"`
 
-	// Custom pingdom request headers
+	// Custom request headers
 	// +optional
 	RequestHeaders string `json:"requestHeaders,omitempty"`
+
+	// Custom request headers that should be read from an environment variable as it possibly contains sensitive data.
+	// An example would be an API token.
+	// +optional
+	RequestHeadersEnvVar string `json:"requestHeadersEnvVar,omitempty"`
 
 	// Required for basic-authentication
 	// +optional
@@ -287,7 +292,7 @@ type PingdomConfig struct {
 
 	// Data that should be posted to the web page, for example submission data for a sign-up or login form.
 	// The data needs to be formatted in the same way as a web browser would send it to the web server.
-	// Because post data contains sensitive secret this field is only reference to a environment variable.
+	// Because post data contains sensitive secret this field is only a reference to an environment variable.
 	// +optional
 	PostDataEnvVar string `json:"postDataEnvVar,omitempty"`
 }

--- a/charts/ingressmonitorcontroller/crds/endpointmonitor.stakater.com_endpointmonitors.yaml
+++ b/charts/ingressmonitorcontroller/crds/endpointmonitor.stakater.com_endpointmonitors.yaml
@@ -93,10 +93,15 @@ spec:
                       submission data for a sign-up or login form. The data needs
                       to be formatted in the same way as a web browser would send
                       it to the web server. Because post data contains sensitive secret
-                      this field is only reference to a environment variable.
+                      this field is only a reference to an environment variable.
                     type: string
                   requestHeaders:
-                    description: Custom pingdom request headers
+                    description: Custom request headers
+                    type: string
+                  requestHeadersEnvVar:
+                    description: Custom request headers that should be read from an
+                      environment variable as it possibly contains sensitive data.
+                      An example would be an API token.
                     type: string
                   resolution:
                     description: The pingdom check interval in minutes

--- a/config/crd/bases/endpointmonitor.stakater.com_endpointmonitors.yaml
+++ b/config/crd/bases/endpointmonitor.stakater.com_endpointmonitors.yaml
@@ -93,10 +93,15 @@ spec:
                       submission data for a sign-up or login form. The data needs
                       to be formatted in the same way as a web browser would send
                       it to the web server. Because post data contains sensitive secret
-                      this field is only reference to a environment variable.
+                      this field is only a reference to an environment variable.
                     type: string
                   requestHeaders:
-                    description: Custom pingdom request headers
+                    description: Custom request headers
+                    type: string
+                  requestHeadersEnvVar:
+                    description: Custom request headers that should be read from an 
+                      environment variable as it possibly contains sensitive data.
+                      An example would be an API token.
                     type: string
                   resolution:
                     description: The pingdom check interval in minutes

--- a/config/crd/bases/endpointmonitor.stakater.com_endpointmonitors.yaml
+++ b/config/crd/bases/endpointmonitor.stakater.com_endpointmonitors.yaml
@@ -99,7 +99,7 @@ spec:
                     description: Custom request headers
                     type: string
                   requestHeadersEnvVar:
-                    description: Custom request headers that should be read from an 
+                    description: Custom request headers that should be read from an
                       environment variable as it possibly contains sensitive data.
                       An example would be an API token.
                     type: string

--- a/pkg/controllers/endpointmonitor_deleted.go
+++ b/pkg/controllers/endpointmonitor_deleted.go
@@ -39,7 +39,7 @@ func (r *EndpointMonitorReconciler) removeMonitorIfExists(monitorService *monito
 	// Monitor Exists
 	if monitor != nil {
 		// Monitor Exists, remove the monitor
-		log.Info("Removing monitor: " + monitorName + " from provider provider: " + monitorService.GetType())
+		log.Info("Removing monitor: " + monitorName + " from provider: " + monitorService.GetType())
 		monitorService.Remove(*monitor)
 	} else {
 		log.Info("Cannot find monitor with name: " + monitorName + " for provider: " + monitorService.GetType())

--- a/pkg/monitors/pingdomtransaction/pingdom-transaction-monitor.go
+++ b/pkg/monitors/pingdomtransaction/pingdom-transaction-monitor.go
@@ -40,7 +40,7 @@ type PingdomTransactionMonitorService struct {
 	namespace         string
 }
 
-func (monitor *PingdomTransactionMonitorService) Equal(oldMonitor models.Monitor, newMonitor models.Monitor) bool {
+func (service *PingdomTransactionMonitorService) Equal(oldMonitor models.Monitor, newMonitor models.Monitor) bool {
 	// TODO: Retrieve oldMonitor config and compare it here
 	return false
 }
@@ -105,7 +105,7 @@ func (service *PingdomTransactionMonitorService) GetAll() []models.Monitor {
 func (service *PingdomTransactionMonitorService) GetUrlFromSteps(id int64) string {
 	check, _, err := service.client.TMSChecksAPI.GetCheck(service.context, id).Execute()
 	if err != nil {
-		log.Error(err, "Error getting transaction check")
+		log.Error(err, "Error getting transaction check", "id", id)
 		return ""
 	}
 	if check == nil {
@@ -140,10 +140,10 @@ func (service *PingdomTransactionMonitorService) Update(m models.Monitor) {
 	monitorID := util.StrToInt64(m.ID)
 	_, resp, err := service.client.TMSChecksAPI.ModifyCheck(service.context, monitorID).CheckWithoutIDPUT(*transactionCheck.AsPut()).Execute()
 	if err != nil {
-		log.Error(err, "Error Updating Pingdom Transaction Monitor", "Response", parseResponseBody(resp))
+		log.Error(err, "Error updating Pingdom Transaction Monitor", "Response", parseResponseBody(resp))
 		return
 	}
-	log.Info("Updated Pingdom Transaction Monitor Monitor " + m.Name)
+	log.Info("Successfully updated Pingdom Transaction Monitor " + m.Name)
 }
 
 func (service *PingdomTransactionMonitorService) Remove(m models.Monitor) {
@@ -177,19 +177,19 @@ func (service *PingdomTransactionMonitorService) createTransactionCheck(monitor 
 	if teamAlertContacts != nil {
 		transactionCheck.TeamIds = teamAlertContacts
 	}
-	service.addConfigToTranscationCheck(transactionCheck, monitor)
+	service.addConfigToTransactionCheck(transactionCheck, monitor)
 
 	return transactionCheck
 }
 
-func (service *PingdomTransactionMonitorService) addConfigToTranscationCheck(transactionCheck *pingdomNew.CheckWithoutID, monitor models.Monitor) {
+func (service *PingdomTransactionMonitorService) addConfigToTransactionCheck(transactionCheck *pingdomNew.CheckWithoutID, monitor models.Monitor) {
 
 	// Retrieve provider configuration
 	config := monitor.Config
 	providerConfig, _ := config.(*endpointmonitorv1alpha1.PingdomTransactionConfig)
 
 	if providerConfig == nil {
-		// providerConfig is not set, we create a go_to transaction by default from url because its required by API
+		// providerConfig is not set, we create a go_to transaction by default from url because it's required by API
 		transactionCheck.Steps = append(transactionCheck.Steps, pingdomNew.Step{
 			Args: &pingdomNew.StepArgs{
 				Url: ptr.String(monitor.URL),
@@ -233,7 +233,7 @@ func (service *PingdomTransactionMonitorService) addConfigToTranscationCheck(tra
 		transactionCheck.SeverityLevel = ptr.String(providerConfig.SeverityLevel)
 	}
 	if providerConfig.Interval > 0 {
-		transactionCheck.Interval = ptr.Int64((int64(providerConfig.Interval)))
+		transactionCheck.Interval = ptr.Int64(int64(providerConfig.Interval))
 	}
 	for _, step := range providerConfig.Steps {
 		args := service.NewStepArgsByMap(step.Args)
@@ -369,7 +369,7 @@ func parseResponseBody(resp *http.Response) string {
 	// Attempt to unmarshal the response body into a map
 	var responseBodyMap map[string]map[string]interface{}
 	if err := json.Unmarshal(bodyBytes, &responseBodyMap); err != nil {
-		// If unmarshaling fails, return the whole body as a string.
+		// If unmarshalling fails, return the whole body as a string.
 		return string(bodyBytes)
 	}
 	// Check if "error" key exists in the map

--- a/pkg/monitors/pingdomtransaction/pingdom-transaction-monitor_test.go
+++ b/pkg/monitors/pingdomtransaction/pingdom-transaction-monitor_test.go
@@ -48,8 +48,8 @@ func TestAddMonitorWithCorrectValues(t *testing.T) {
 
 	service.Setup(*provider)
 	m := models.Monitor{
-		Name: "google-test",
-		URL:  "https://google.com",
+		Name:   "google-test",
+		URL:    "https://google.com",
 		Config: spec,
 	}
 


### PR DESCRIPTION
We would like to read request headers from the environment (similar to post data) as it may contain sensitive data, e.g., an api token in the `Authorization` header. Therefore, this PR adds a new field to the pingdomConfig named `requestHeadersEnvVar` that mimics the behavior of `postDataEnvVar`.